### PR TITLE
fix: remove reference to nonexistent rss.xsl stylesheet

### DIFF
--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -16,7 +16,6 @@ export async function GET(_context: AstroGlobal) {
   }
   const posts = await getSortedPosts()
   return rss({
-    stylesheet: '/rss.xsl',
     title: siteConfig.title,
     description: siteConfig.description,
     site: siteConfig.site,


### PR DESCRIPTION
## Summary
- `rss.xml.ts` referenced `stylesheet: '/rss.xsl'` but no such file exists under `public/`, so requests for it 404'd
- Removed the reference; feed readers don't need the stylesheet to parse the XML

## Test plan
- [x] `pnpm exec astro build` locally, confirmed `dist/rss.xml` has no stylesheet PI and parses fine

Closes #84