### PR TITLE
fix: set html lang to ja

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -120,7 +120,7 @@ let generatedCss: string = cssLines.join('\n')
 
 <!doctype html>
 <html
-  lang="en"
+  lang="ja"
   data-theme={defaultTheme}
   data-dark-theme={darkTheme}
   data-light-theme={lightTheme}


### PR DESCRIPTION
## Summary
- `<html>` was declared `lang="en"` in `src/layouts/Layout.astro`, but the site content is almost entirely Japanese
- Fixed to `lang="ja"` for correct screen-reader pronunciation and SEO signals

Closes #85