### PR TITLE
fix: a11y issues in header/theme/scroll controls

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -27,7 +27,7 @@ const showLightDarkButton =
       <Search trailingSlashes={siteConfig.trailingSlashes} />
       {selectTheme && <SelectTheme />}
       {showLightDarkButton && <LightDarkAutoButton />}
-      <nav id="nav-mobile" aria-label="Menu" class="p-0 text-accent sm:hidden">
+      <nav id="nav-mobile" aria-label="Mobile menu" class="p-0 text-accent sm:hidden">
         <button
           id="nav-mobile-button"
           class="px-3 py-1 h-full cursor-pointer border-2 rounded-xl bg-background"
@@ -43,7 +43,7 @@ const showLightDarkButton =
         >
           {
             siteConfig.navLinks.map((link) => (
-              <li class="p-1" aria-expanded="false">
+              <li class="p-1">
                 <NavLink link={link} />
               </li>
             ))
@@ -52,11 +52,11 @@ const showLightDarkButton =
       </nav>
     </div>
   </div>
-  <nav aria-label="Menu" class="p-0 mt-4 ml-0.5 text-accent hidden sm:block">
+  <nav aria-label="Main menu" class="p-0 mt-4 ml-0.5 text-accent hidden sm:block">
     <ul class="flex flex-row text-accent">
       {
         siteConfig.navLinks.map((link) => (
-          <li class="mr-5" aria-expanded="true">
+          <li class="mr-5">
             <NavLink link={link} />
           </li>
         ))
@@ -68,7 +68,6 @@ const showLightDarkButton =
 <script>
   const navMobileButton = document.getElementById('nav-mobile-button')
   const navMobileList = document.getElementById('nav-mobile-list')
-  const navMobileListItems = navMobileList?.querySelectorAll('li')
   const toggleNavMobileMenu = (action: 'on' | 'off' | 'toggle') => {
     let isNowOpen: boolean = false
     if (action === 'on') {
@@ -81,9 +80,6 @@ const showLightDarkButton =
       isNowOpen = !navMobileList?.classList.toggle('invisible')
     }
     navMobileButton?.setAttribute('aria-expanded', isNowOpen ? 'true' : 'false')
-    navMobileListItems?.forEach((listItem) => {
-      listItem.setAttribute('aria-expanded', isNowOpen ? 'true' : 'false')
-    })
   }
   navMobileButton?.addEventListener('click', (_ev) => {
     toggleNavMobileMenu('toggle')

--- a/src/components/LightDarkAutoButton.astro
+++ b/src/components/LightDarkAutoButton.astro
@@ -11,11 +11,18 @@ const showLightFirst = defaultTheme === lightTheme
 <button
   id="theme-change-button"
   class="block ml-auto"
+  aria-label="Toggle light / dark theme"
   data-light={lightTheme}
   data-dark={darkTheme}
 >
-  <IconSun id="icon-light" class:list={['size-6 text-accent', showLightFirst ? '' : 'hidden']} />
-  <IconMoon id="icon-dark" class:list={['size-6 text-accent', showLightFirst ? 'hidden' : '']} />
+  <IconSun
+    id="icon-light"
+    class:list={['size-6 text-accent', showLightFirst ? '' : 'hidden']}
+  />
+  <IconMoon
+    id="icon-dark"
+    class:list={['size-6 text-accent', showLightFirst ? 'hidden' : '']}
+  />
 </button>
 <script is:inline>
   ;(function () {

--- a/src/components/ScrollUpButton.astro
+++ b/src/components/ScrollUpButton.astro
@@ -4,6 +4,7 @@ import IconChevronUp from '~/icons/chevron-up.svg'
 
 <button
   hidden
+  aria-label="Scroll to top"
   class="scroll-up size-11 fixed flex items-center justify-center bg-background z-100 bottom-3 right-3 rounded-full border-2 border-accent/20 hover:bg-accent/10 md:size-12 md:bottom-5 md:right-5 lg:size-13 lg:bottom-6 lg:right-6"
 >
   <IconChevronUp class="text-accent/50 size-8 lg:size-9" />

--- a/src/components/SelectTheme.astro
+++ b/src/components/SelectTheme.astro
@@ -12,10 +12,9 @@ function kebabToTitleCase(str: string): string {
 }
 ---
 
-<select-theme class="ms-auto" id="search">
+<select-theme class="ms-auto" id="select-theme">
   <button
     class="hover:text-accent flex cursor-pointer items-center justify-center rounded-md"
-    aria-keyshortcuts="Control+K Meta+K"
     data-open-modal
     disabled
   >
@@ -112,13 +111,6 @@ function kebabToTitleCase(str: string): string {
       })
     }
 
-    connectedCallback() {
-      // window events, requires cleanup
-      window.addEventListener('keydown', this.onWindowKeydown, {
-        signal: this.#controller.signal,
-      })
-    }
-
     disconnectedCallback() {
       this.#controller.abort()
     }
@@ -152,18 +144,6 @@ function kebabToTitleCase(str: string): string {
           !this.#dialogFrame?.contains(event.target as Node))
       ) {
         this.closeModal()
-      }
-    }
-
-    onWindowKeydown = (e: KeyboardEvent) => {
-      if (!this.#dialog) {
-        console.warn('Dialog not found')
-        return
-      }
-      // check if it's the Control+K or ⌘+K shortcut
-      if ((e.metaKey === true || e.ctrlKey === true) && e.key === 'k') {
-        this.#dialog.open ? this.closeModal() : this.openModal()
-        e.preventDefault()
       }
     }
 


### PR DESCRIPTION
## Summary
- Add `aria-label` to icon-only buttons (theme toggle, scroll-to-top) — previously no accessible name for screen readers
- Remove invalid `aria-expanded` on `<li>` elements in Header (only valid on the toggle button itself); drop the now-dead script code that set it on list items
- Disambiguate the two `<nav aria-label="Menu">` landmarks to "Mobile menu" / "Main menu"
- Fix duplicate `id="search"` between `Search` and `SelectTheme` components, and remove `SelectTheme`'s competing global Ctrl+K/Cmd+K handler + `aria-keyshortcuts` — previously both dialogs opened simultaneously on Ctrl+K when theme select mode is enabled (which is the current site config)

## Test plan
- [x] `pnpm exec astro build` locally, spot-checked generated HTML for aria-labels / no duplicate ids

Closes #97
Closes #98
Closes #109