### PR TITLE
fix: improve 404 page with a link back home

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -2,6 +2,10 @@
 import Layout from '~/layouts/Layout.astro'
 ---
 
-<Layout>
-  <h1 class="inline-block m-auto p-4 text-accent text-4xl">404</h1>
+<Layout title="Page Not Found">
+  <div class="flex flex-col items-center gap-4 m-auto p-4 text-center">
+    <h1 class="text-accent text-4xl">404</h1>
+    <p>お探しのページは見つかりませんでした。</p>
+    <a href="/" class="button">トップページに戻る</a>
+  </div>
 </Layout>


### PR DESCRIPTION
## Summary
- 404 page was just a bare "404" heading with no way to navigate back into the site
- Added a short message and a link back to the top page, and a proper page title

Closes #103