### PR TITLE
fix: register a CJK fallback font for OG image generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@astrojs/sitemap": "^3.7.3",
     "@astrojs/ts-plugin": "^1.10.9",
     "@expo-google-fonts/jetbrains-mono": "^0.4.1",
+    "@expo-google-fonts/noto-sans-jp": "^0.4.3",
     "@expressive-code/plugin-line-numbers": "^0.42.0",
     "@fontsource-variable/jetbrains-mono": "^5.2.8",
     "@pagefind/default-ui": "^1.5.2",
@@ -52,12 +53,12 @@
     "sanitize-html": "^2.17.4",
     "satori": "^0.26.0",
     "satori-html": "^0.3.2",
+    "sharp": "^0.34.5",
     "stream-replace-string": "^2.0.0",
     "tailwindcss": "^4.3.0",
     "typescript": "^5.9.3",
     "unified": "^11.0.5",
-    "unist-util-visit": "^5.1.0",
-    "sharp": "^0.34.5"
+    "unist-util-visit": "^5.1.0"
   },
   "devDependencies": {
     "@types/markdown-it": "^14.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@expo-google-fonts/jetbrains-mono':
         specifier: ^0.4.1
         version: 0.4.1
+      '@expo-google-fonts/noto-sans-jp':
+        specifier: ^0.4.3
+        version: 0.4.3
       '@expressive-code/plugin-line-numbers':
         specifier: ^0.42.0
         version: 0.42.0
@@ -406,6 +409,9 @@ packages:
 
   '@expo-google-fonts/jetbrains-mono@0.4.1':
     resolution: {integrity: sha512-CslACrtMOcRwoWXCO7OMEI+9w3fukWSoBtvNz46OqPoogEuuoY0tkDY1O8sFumk8t0pC6Cx0Xr95O0TOQhpkug==}
+
+  '@expo-google-fonts/noto-sans-jp@0.4.3':
+    resolution: {integrity: sha512-Fl+Z6vtD24HFAYsvzB0S9Nery1ly16B9PesdY0wBd+wEHAvkNglnkTUspU0HqGOubkmoa8zusJrKv6vDx1o70A==}
 
   '@expressive-code/core@0.42.0':
     resolution: {integrity: sha512-MN11+9nfmaC7sYu2BZJXAXqwkBRt8t1xTSqP+Ti1NfTEskgl6xUnzDxoaiQkg0BMzpglA0pys4dpDKquP/cyIw==}
@@ -2977,6 +2983,8 @@ snapshots:
     optional: true
 
   '@expo-google-fonts/jetbrains-mono@0.4.1': {}
+
+  '@expo-google-fonts/noto-sans-jp@0.4.3': {}
 
   '@expressive-code/core@0.42.0':
     dependencies:

--- a/src/pages/social-cards/[slug].png.ts
+++ b/src/pages/social-cards/[slug].png.ts
@@ -8,11 +8,18 @@ import path from 'path'
 import fs from 'fs'
 import type { ReactNode } from 'react'
 
-// Load the font file as binary data
+// Load the font files as binary data
 const fontPath = path.resolve(
   './node_modules/@expo-google-fonts/jetbrains-mono/400Regular/JetBrainsMono_400Regular.ttf',
 )
 const fontData = fs.readFileSync(fontPath) // Reads the file as a Buffer
+
+// JetBrains Mono has no CJK glyphs, so titles in Japanese (etc.) rendered blank/tofu
+// without a fallback font registered alongside it.
+const cjkFontPath = path.resolve(
+  './node_modules/@expo-google-fonts/noto-sans-jp/400Regular/NotoSansJP_400Regular.ttf',
+)
+const cjkFontData = fs.readFileSync(cjkFontPath)
 
 const avatarPath = path.resolve(siteConfig.socialCardAvatarImage)
 let avatarData: Buffer | undefined
@@ -49,6 +56,12 @@ const ogOptions: SatoriOptions = {
     {
       data: fontData,
       name: 'JetBrains Mono',
+      style: 'normal',
+      weight: 400,
+    },
+    {
+      data: cjkFontData,
+      name: 'Noto Sans JP',
       style: 'normal',
       weight: 400,
     },


### PR DESCRIPTION
## Summary
- satori only had JetBrains Mono registered for OG image generation, which has no CJK glyphs — Japanese article titles rendered as tofu (□□□) in every generated OG image, affecting nearly all posts on this Japanese-language blog
- Added `@expo-google-fonts/noto-sans-jp` as a second registered font; satori falls back to it for glyphs JetBrains Mono doesn't cover

## Test plan
- [x] `pnpm exec astro build` locally, confirmed Japanese title now renders correctly in `dist/social-cards/first-blog.png` (previously all boxes)

Closes #106