### PR TITLE
fix: GitHub Activity Calendarを最新週まで自動スクロール

### DIFF
--- a/src/components/GitHubActivityCalendar.astro
+++ b/src/components/GitHubActivityCalendar.astro
@@ -278,14 +278,6 @@ const height = labelHeight + (blockSize + blockMargin) * 7 - blockMargin
           ))}
         </svg>
       </div>
-      <script>
-        const scrollContainer = document.querySelector<HTMLElement>(
-          '#github-activity-calendar .overflow-x-auto',
-        )
-        if (scrollContainer) {
-          scrollContainer.scrollLeft = scrollContainer.scrollWidth
-        }
-      </script>
       {!(hideTotalCount && hideColorLegend) && (
         <footer class="flex flex-col sm:flex-row sm:justify-between gap-x-1 gap-y-2">
           {!hideTotalCount && (
@@ -320,3 +312,11 @@ const height = labelHeight + (blockSize + blockMargin) * 7 - blockMargin
     </article>
   )
 }
+<script>
+  const scrollContainer = document.querySelector(
+    '#github-activity-calendar .overflow-x-auto',
+  )
+  if (scrollContainer) {
+    scrollContainer.scrollLeft = scrollContainer.scrollWidth
+  }
+</script>

--- a/src/components/GitHubActivityCalendar.astro
+++ b/src/components/GitHubActivityCalendar.astro
@@ -278,6 +278,14 @@ const height = labelHeight + (blockSize + blockMargin) * 7 - blockMargin
           ))}
         </svg>
       </div>
+      <script>
+        const scrollContainer = document.querySelector<HTMLElement>(
+          '#github-activity-calendar .overflow-x-auto',
+        )
+        if (scrollContainer) {
+          scrollContainer.scrollLeft = scrollContainer.scrollWidth
+        }
+      </script>
       {!(hideTotalCount && hideColorLegend) && (
         <footer class="flex flex-col sm:flex-row sm:justify-between gap-x-1 gap-y-2">
           {!hideTotalCount && (


### PR DESCRIPTION
## Summary
- 読み込み時に横スクロール位置が左端(最古週)のままになっており、最新の活動が見えにくかった問題を修正
- コンテナのマウント時に `scrollLeft = scrollWidth` を設定し、右端(最新週)まで自動スクロールするようにした

Fixes #11

## Test plan
- [x] `npx astro check` でエラーなしを確認
- [x] ローカルの dev サーバーでブラウザ確認: 修正前は `scrollLeft: 0`（Oct 表示）、修正後は自動で `scrollLeft: 174`（最新の Jul まで表示）になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)