### PR TITLE
feat: ナビゲーションにResumeへのリンクを追加

### DIFF
--- a/src/site.config.ts
+++ b/src/site.config.ts
@@ -26,6 +26,7 @@ const config: SiteConfig = {
     { name: 'About', url: '/about' },
     { name: 'Blog', url: '/blog' },
     { name: 'GitHub', url: 'https://github.com/sugiyan97', external: true },
+    { name: 'Resume', url: 'https://sugiyan97.github.io/resume/', external: true },
   ],
   // テーマ: light-dark-auto モードでライト/ダークの自動切替のみを行う
   // （テーマ選択ダイアログは表示しない）。github-light / github-dark を


### PR DESCRIPTION
## Summary
- ナビゲーション（デスクトップ/モバイル両方）に「Resume」リンクを追加
- リンク先は職務経歴書ページ https://sugiyan97.github.io/resume/ (issue内で参照されている sugiyan97/resume リポジトリのGitHub Pages公開先)
- 既存の GitHub リンクと同様の `external: true` パターンを使用し、新規タブで開くようにした

Closes #2

## Test plan
- [x] `pnpm lint` が通ることを確認
- [x] `pnpm run format:check` が通ることを確認
- [x] `pnpm run build` が成功し、生成された `dist/index.html` に Resume リンクが正しく出力されることを確認
- [x] デプロイプレビューでモバイル/デスクトップ両方のナビ表示を目視確認