### PR TITLE
chore: ブランチ命名規則をルール化しCIで強制する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: ['main']
   pull_request:
-    branches: ['main', 'feat/*', 'fix/*']
+    branches: ['main']
     types: [opened, synchronize, reopened]
 
 permissions:
@@ -14,6 +14,25 @@ env:
   BUILD_PATH: '.'
 
 jobs:
+  branch-name-check:
+    name: Branch name check
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate branch name
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          if [[ "$HEAD_REF" =~ ^dependabot/ ]]; then
+            echo "Dependabot branch, skipping check: $HEAD_REF"
+            exit 0
+          fi
+          if [[ ! "$HEAD_REF" =~ ^(feat|fix|docs|chore|refactor|test|ci)/[a-z0-9._-]+$ ]]; then
+            echo "::error::ブランチ名 '$HEAD_REF' が命名規則に従っていません。<type>/<kebab-case-description> の形式にしてください（type: feat, fix, docs, chore, refactor, test, ci）。詳細は CONTRIBUTING.md を参照してください。"
+            exit 1
+          fi
+          echo "Branch name '$HEAD_REF' is valid."
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+# Contributing
+
+## ブランチ命名規則
+
+ブランチ名は以下の形式にしてください。
+
+```
+<type>/<kebab-case-description>
+```
+
+`type` は以下のいずれかを使用します。
+
+| type       | 用途                               |
+| ---------- | ---------------------------------- |
+| `feat`     | 新機能の追加                       |
+| `fix`      | バグ修正                           |
+| `docs`     | ドキュメントのみの変更             |
+| `chore`    | ビルド設定・依存関係更新などの雑務 |
+| `refactor` | 挙動を変えないコードの整理         |
+| `test`     | テストの追加・修正                 |
+| `ci`       | CI/CD 設定の変更                   |
+
+例:
+
+```
+feat/add-resume-nav-link
+fix/rss-stylesheet-404
+docs/update-readme
+chore/pin-node-version
+refactor/simplify-nav-link
+test/add-vitest-utils
+ci/harden-github-actions
+```
+
+Dependabot が自動作成するブランチ（`dependabot/...`）はこの規則の対象外です。
+
+この規則に従わない PR は `.github/workflows/ci.yml` の branch-name-check ジョブで CI が失敗します。

--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ pnpm dev       # http://localhost:4321 で開発サーバーを起動
 - GitHub Actions（`.github/workflows/ci.yml`）で push / PR ごとに format check・型チェック・ビルドを実行しています。
 - 本番デプロイは [Cloudflare Pages](https://pages.cloudflare.com/) が `main` ブランチを追跡してビルド・公開しています（ビルドコマンド: `pnpm build`、出力ディレクトリ: `dist`）。
 
+## ブランチ命名規則
+
+ブランチ名は `<type>/<kebab-case-description>` の形式にしてください（例: `feat/add-resume-nav-link`）。
+詳細は [CONTRIBUTING.md](./CONTRIBUTING.md) を参照してください。
+
 ## 記事の書き方
 
 記事は `src/content/blogs/` 配下に Markdown（`.md`）または MDX（`.mdx`）で追加します。


### PR DESCRIPTION
## Summary
- `CONTRIBUTING.md` を新規作成し、ブランチ命名規則（`<type>/<kebab-case-description>`、type は `feat`/`fix`/`docs`/`chore`/`refactor`/`test`/`ci`）を明文化
- README.md にも簡単な導線を追加
- `.github/workflows/ci.yml` に `branch-name-check` ジョブを追加し、PRのhead branch名が規則に沿っているかを正規表現で検証・強制（dependabotブランチは対象外）
- あわせて既存の `pull_request.branches: ['main', 'feat/*', 'fix/*']` を整理。**このフィルタはPRのbase branchに対して評価されるため、head branch名の絞り込みとしては機能していなかった**（実際に `design/washi-theme` のようなfeat/fix以外のhead branchのPRでもCIは起動していたことを確認済み）。base=mainへのフィルタのみ残し、head branch名の検証は新設のジョブに置き換えた。

## Test plan
- [x] `pnpm run format:check` / `pnpm run lint` / `pnpm run build` がローカルで通ることを確認
- [x] 追加した正規表現ロジックをローカルでシェルスクリプトとして再現し、`feat/add-resume-nav-link` 等はOK、`design/washi-theme` や `pr-130` のような非準拠名はFAILになることを確認
- [x] このPR自体（`chore/add-branch-naming-rule`）で `branch-name-check` ジョブが実際にpassすることをCI上で確認